### PR TITLE
DerpSpace: Add horizon light settings [2/2]

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -249,4 +249,13 @@
     <string name="bottom">Unten</string>
     <string name="show_auto_brightness_button_title">Symbol für autom. Helligkeit anzeigen</string>
 
+    <!-- Pulse -->
+    <string name="ambient_light_category">Kantenbeleuchtung</string>
+    <string name="pulse_ambient_light_text">Die Kantenbeleuchtung lässt Ihren Bildschirm leuchten, wenn Sie eine Benachrichtigung erhalten. Dies macht es einfacher zu erkennen, wenn Sie eine Benachrichtigung erhalten, während sich das Telefon im Ruhemodus befindet.</string>
+    <string name="pulse_ambient_light_title">Kantenbeleuchtung</string>
+    <string name="pulse_ambient_light_summary">Beleuchtet die Seitenränder des Bildschirms bei einem Benachrichtigungsimpuls</string>
+    <string name="ambient_notification_light_accent_title">Systemakzentfarbe</string>
+    <string name="ambient_notification_light_color_automatic_title">Benachrichtigungsfarbe</string>
+    <string name="pulse_ambient_light_color">Beleuchtung mit</string>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -258,4 +258,14 @@
     <string name="bottom">Bottom</string>
     <string name="show_auto_brightness_button_title">Show auto brightness button</string>
 
+    <!-- Pulse -->
+    <string name="ambient_light_category">Edge lighting</string>
+    <string name="keywords_pulse_ambient_light_display">notification, notifications, edge, light, colour, color</string>
+    <string name="pulse_ambient_light_text">Edge lighting makes your screen glow when you receive a notification. This makes it easier to figure when you get a pulse while the phone is doze mode.</string>
+    <string name="pulse_ambient_light_title">Edge lighting</string>
+    <string name="pulse_ambient_light_summary">Light up the side edges of the screen on notification pulse</string>
+    <string name="ambient_notification_light_accent_title">System accent color</string>
+    <string name="ambient_notification_light_color_automatic_title">Notification color</string>
+    <string name="pulse_ambient_light_color">When pulsing, use</string>
+
 </resources>

--- a/res/xml/notifications.xml
+++ b/res/xml/notifications.xml
@@ -22,6 +22,18 @@
     android:title="@string/notifications_title">
 
     <PreferenceCategory
+        android:key="ambient_light"
+        android:title="@string/ambient_light_category" >
+
+        <Preference
+            android:key="pulse_ambient_light_settings"
+            android:title="@string/pulse_ambient_light_title"
+            android:summary="@string/pulse_ambient_light_summary"
+            android:fragment="org.derpfest.derpspace.fragments.PulseAmbientLightSettings" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:key="reticker"
         android:title="@string/reticker_category" >
 

--- a/res/xml/pulse_ambient_light_settings.xml
+++ b/res/xml/pulse_ambient_light_settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2020 Paranoid Android
+     Copyright (C) 2022 Project 404
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:key="pulse_ambient_light_settings"
+    android:title="@string/pulse_ambient_light_title"
+    settings:keywords="@string/keywords_pulse_ambient_light_display">
+
+    <com.android.settingslib.widget.TopIntroPreference
+        android:key="pulse_ambient_light_top_intro"
+        android:title="@string/pulse_ambient_light_text"/>
+
+    <PreferenceCategory
+        android:title="@string/pulse_ambient_light_color">
+
+        <com.android.settingslib.widget.RadioButtonPreference
+            android:key="ambient_notification_light_automatic"
+            android:title="@string/ambient_notification_light_color_automatic_title" />
+
+        <com.android.settingslib.widget.RadioButtonPreference
+            android:key="ambient_notification_light_accent"
+            android:title="@string/ambient_notification_light_accent_title" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/src/org/derpfest/derpspace/fragments/PulseAmbientLightSettings.java
+++ b/src/org/derpfest/derpspace/fragments/PulseAmbientLightSettings.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2020 Paranoid Android
+ * Copyright (C) 2022 Project 404
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.derpfest.derpspace.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.widget.Switch;
+
+import androidx.preference.Preference;
+
+import com.android.internal.logging.nano.MetricsProto;
+
+import com.android.settings.R;
+import com.android.settings.SettingsActivity;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settings.widget.SettingsMainSwitchBar;
+import com.android.settingslib.widget.OnMainSwitchChangeListener;
+import com.android.settingslib.widget.RadioButtonPreference;
+
+public class PulseAmbientLightSettings extends SettingsPreferenceFragment
+        implements Preference.OnPreferenceClickListener {
+
+    private static final String TAG = "PulseAmbientLightSettings";
+
+    private static final String COLOR_AUTOMATIC = "ambient_notification_light_automatic";
+    private static final String COLOR_ACCENT = "ambient_notification_light_accent";
+
+    private PulseAmbientLightEnabler mPulseAmbientLightEnabler;
+    private RadioButtonPreference mColorAutomatic;
+    private RadioButtonPreference mColorAccent;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.pulse_ambient_light_settings);
+        mColorAutomatic = (RadioButtonPreference) findPreference(COLOR_AUTOMATIC);
+        mColorAccent = (RadioButtonPreference) findPreference(COLOR_ACCENT);
+
+        mColorAutomatic.setOnPreferenceClickListener(this);
+        mColorAccent.setOnPreferenceClickListener(this);
+
+        boolean colorAuto = Settings.System.getIntForUser(getContentResolver(), COLOR_AUTOMATIC, 1, UserHandle.USER_CURRENT) != 0;
+        updateState(colorAuto ? COLOR_AUTOMATIC : COLOR_ACCENT);
+    }
+
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        final String key = preference.getKey();
+        if (preference instanceof RadioButtonPreference) {
+            updateState(key);
+        }
+        return true;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.DERP;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (mPulseAmbientLightEnabler != null) {
+            mPulseAmbientLightEnabler.teardownSwitchBar();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        SettingsActivity activity = (SettingsActivity) getActivity();
+        mPulseAmbientLightEnabler = new PulseAmbientLightEnabler(activity.getSwitchBar());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mPulseAmbientLightEnabler != null) {
+            mPulseAmbientLightEnabler.resume();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mPulseAmbientLightEnabler != null) {
+            mPulseAmbientLightEnabler.pause();
+        }
+    }
+
+    private void updateState(String key) {
+        if (key.equals(COLOR_AUTOMATIC)) {
+            Settings.System.putIntForUser(getContentResolver(),
+                COLOR_AUTOMATIC, 1, UserHandle.USER_CURRENT);
+            mColorAutomatic.setChecked(true);
+            mColorAccent.setChecked(false);
+        } else {
+            Settings.System.putIntForUser(getContentResolver(),
+                COLOR_AUTOMATIC, 0, UserHandle.USER_CURRENT);
+            mColorAutomatic.setChecked(false);
+            mColorAccent.setChecked(true);
+        }
+    }
+
+    private void updateDependencies(boolean enabled) {
+        mColorAutomatic.setEnabled(enabled);
+        mColorAccent.setEnabled(enabled);
+    }
+
+    private class PulseAmbientLightEnabler implements OnMainSwitchChangeListener {
+
+        private final Context mContext;
+        private final SettingsMainSwitchBar mSwitchBar;
+        private boolean mListeningToOnSwitchChange;
+
+        public PulseAmbientLightEnabler(SettingsMainSwitchBar switchBar) {
+            mContext = switchBar.getContext();
+            mSwitchBar = switchBar;
+            mSwitchBar.setTitle("Use Edge lighting");
+
+            mSwitchBar.show();
+
+            boolean enabled = Settings.System.getIntForUser(
+                    mContext.getContentResolver(),
+                    Settings.System.AMBIENT_NOTIFICATION_LIGHT, 1, UserHandle.USER_CURRENT) != 0;
+            mSwitchBar.setChecked(enabled);
+            PulseAmbientLightSettings.this.updateDependencies(enabled);
+        }
+
+        public void teardownSwitchBar() {
+            pause();
+            mSwitchBar.hide();
+        }
+
+        public void resume() {
+            if (!mListeningToOnSwitchChange) {
+                mSwitchBar.addOnSwitchChangeListener(this);
+                mListeningToOnSwitchChange = true;
+            }
+        }
+
+        public void pause() {
+            if (mListeningToOnSwitchChange) {
+                mSwitchBar.removeOnSwitchChangeListener(this);
+                mListeningToOnSwitchChange = false;
+            }
+        }
+
+        @Override
+        public void onSwitchChanged(Switch switchView, boolean isChecked) {
+            Settings.System.putIntForUser(
+                    mContext.getContentResolver(),
+                    Settings.System.AMBIENT_NOTIFICATION_LIGHT, isChecked ? 1 : 0, UserHandle.USER_CURRENT);
+            PulseAmbientLightSettings.this.updateDependencies(isChecked);
+        }
+
+    }
+}


### PR DESCRIPTION
[Hernán Castañón] Settings: rename Horizon Light to Pulse.

mickaelmendes50: Adapt to Android 11

[markakash]:
* Switch to new Material You switchbar
* Adapt for Android 12
* Small changes here and there

Change-Id: Ic54d1e68663774030aad09643af8bccbb0c7e693
Co-Authored-By: Rituj Beniwal <ritujbeniwal@gmail.com>
Co-Authored-By: Hernán Castañón Álvarez <herna@paranoidandroid.co>
Co-Authored-By: Akash Srivastava <akashniki@gmail.com>